### PR TITLE
#9 - User now uses an enum for user status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ CURRENT_BRANCH := `git branch --show-current`
 branch:
 	echo $(CURRENT_BRANCH)
 
+local.console:
+	bundle exec rails console
+
 local.db.console:
 	psql lins_development
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,16 +1,8 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
-  
-  # TODO: https://github.com/swmcc/bookmarks/issues/9 
-  # enum :role, %i[user admin], suffix: true, default: :user 
+  enum :role, %i[user admin], suffix: true, default: :user
 
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
-
-  def admin_role?
-     true
-  end
-
-  def user_role?
-     true
-  end
 end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin', type: :request do
+  context 'when logged in as an administrator' do 
+    describe 'GET /admin' do
+      let!(:user) { create :user, :admin }
+      before do
+        sign_in user
+        get '/admin'
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+  
+  context 'when logged in as a user' do 
+    describe 'GET /admin' do
+      let!(:user) { create :user }
+      before do
+        sign_in user
+        get '/admin'
+      end
+
+      it 'returns status code 302' do
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
+
+  context 'when logged out' do 
+    describe 'GET /admin' do
+      #let!(:user) { create :user }
+      before do
+        get '/admin'
+      end
+
+      it 'returns status code 302' do
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Amended User model to use the new syntax for enum
Added a test to prove that the admin role can only see the admin dashboard